### PR TITLE
Add CLI support for Quick Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # paperpile-to-markdown
-converting papers exported to JSON from Paperpile to a markdown file, to be used in my Obsidian vault.
+Convert Paperpile JSON exports to individual Markdown files for use in my
+Obsidian vault.
+
+## Usage
+
+```
+python pp2md.py path/to/export.json
+```
+
+If no path is supplied the script looks for a ``*.json`` file next to itself.
+
+### macOS Quick Action
+
+The script can be used from a macOS Quick Action by passing the selected
+JSON file as an argument. The generated markdown files are written next to the
+source JSON file so they appear in the same folder after the action finishes.


### PR DESCRIPTION
## Summary
- support passing JSON paths to `pp2md.py`
- generate output next to the input JSON file
- document usage and macOS Quick Action support

## Testing
- `python pp2md.py test.json`

------
https://chatgpt.com/codex/tasks/task_e_688b41bddfd483329a624be976f2262e