### PR TITLE
Add macOS Quick Action helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ If no path is supplied the script looks for a ``*.json`` file next to itself.
 
 ### macOS Quick Action
 
-The script can be used from a macOS Quick Action by passing the selected
-JSON file as an argument. The generated markdown files are written next to the
+The script can be used from a macOS Quick Action by passing the selected JSON
+file as an argument. The generated markdown files are written next to the
 source JSON file so they appear in the same folder after the action finishes.
+
+#### Setting up the Quick Action
+
+1. Copy ``quickaction.sh`` somewhere on your ``$PATH`` and make it executable.
+2. Open **Automator** and create a new **Quick Action**.
+3. Configure the action to receive ``files or folders`` in **Finder** and to
+   ``pass input as arguments``.
+4. Add a **Run Shell Script** step containing the path to ``quickaction.sh``.
+5. Save the workflow (e.g. *Paperpile to Markdown*). Now you can right-click any
+   Paperpile JSON export and run the Quick Action to create the Markdown files
+   next to it.

--- a/quickaction.sh
+++ b/quickaction.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Quick Action script for macOS Finder
+# Converts Paperpile JSON exports to Markdown using pp2md.py.
+
+# Directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Call the converter script with all selected JSON files
+python3 "$SCRIPT_DIR/pp2md.py" "$@"


### PR DESCRIPTION
## Summary
- add `quickaction.sh` to support Finder Quick Actions
- expand README with steps for creating a Quick Action on macOS

## Testing
- `python pp2md.py test.json`

------
https://chatgpt.com/codex/tasks/task_e_688b4c74d4208332865a3c334a79c769