### PR TITLE
Fix Quick Action handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ If no path is supplied the script looks for a ``*.json`` file next to itself.
 
 ### macOS Quick Action
 
-The script can be used from a macOS Quick Action by passing the selected
-JSON file as an argument. The generated markdown files are written next to the
+The script can be used from a macOS Quick Action by passing the selected JSON
+file as an argument. The generated markdown files are written next to the
 source JSON file so they appear in the same folder after the action finishes.
+
+#### Setting up the Quick Action
+
+1. Copy ``quickaction.sh`` somewhere on your ``$PATH`` and make it executable.
+2. Open **Automator** and create a new **Quick Action**.
+3. Configure the action to receive ``files or folders`` in **Finder** and set it
+   to ``pass input as arguments``.
+4. Add a **Run Shell Script** step containing the full path to ``quickaction.sh``.
+5. Set the shell to either ``/bin/zsh`` or ``/bin/bash``.
+6. Save the workflow (e.g. *Paperpile to Markdown*). Now you can right-click any
+   Paperpile JSON export and run the Quick Action to create the Markdown files
+   next to it. The helper script accepts file paths as arguments or via
+   ``stdin`` so it works with either Automator setting.

--- a/quickaction.sh
+++ b/quickaction.sh
@@ -1,0 +1,24 @@
+#!/bin/zsh
+# Quick Action script for macOS Finder
+# Converts Paperpile JSON exports to Markdown using pp2md.py.
+
+# Directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+run_convert() {
+    local json_path="$1"
+    [[ -n "$json_path" ]] || return
+    python3 "$SCRIPT_DIR/pp2md.py" "$json_path"
+}
+
+# Finder may supply paths as arguments or via STDIN depending on the
+# Quick Action configuration. Handle both cases.
+if [[ $# -gt 0 ]]; then
+    for json_path in "$@"; do
+        run_convert "$json_path"
+    done
+else
+    while IFS= read -r json_path; do
+        run_convert "$json_path"
+    done
+fi


### PR DESCRIPTION
## Summary
- support stdin in `quickaction.sh` and switch to zsh
- update Quick Action instructions about shell choice and stdin

## Testing
- `python pp2md.py test.json`

------
https://chatgpt.com/codex/tasks/task_e_688b4c74d4208332865a3c334a79c769